### PR TITLE
iMarket以外からのPDFの表示はページ埋め込みにする

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,13 @@ class ApplicationController < ActionController::Base
 
   before_action :set_variant
 
+  rescue_from ActiveRecord::RecordNotFound, with: :error_404 unless Rails.env.development?
+
   private
+
+  def error_404
+    render file: "#{Rails.root}/public/404.html", layout: false, status: 404
+  end
 
   def set_variant
     request.variant = :sp if browser.device.mobile?

--- a/app/controllers/pdfs_controller.rb
+++ b/app/controllers/pdfs_controller.rb
@@ -1,0 +1,10 @@
+class PdfsController < ApplicationController
+  layout "pdf"
+
+  def show
+    respond_to do |format|
+      format.any
+    end
+  end
+
+end

--- a/app/controllers/pdfs_controller.rb
+++ b/app/controllers/pdfs_controller.rb
@@ -5,11 +5,6 @@ class PdfsController < ApplicationController
     @path = params[:path]
     pdf = @path&.split("/")&.last
     @code = Disclosure.find_by(pdf: pdf)&.code
-
-    respond_to do |format|
-      format.pdf { render file: "#{Rails.root}/public/404.html" }
-      format.any
-    end
   end
 
 end

--- a/app/controllers/pdfs_controller.rb
+++ b/app/controllers/pdfs_controller.rb
@@ -5,9 +5,7 @@ class PdfsController < ApplicationController
     path = params[:path]
     pdf = path&.split("/")&.last
     @pdf = "#{pdf}.pdf"
-    @disclosure = Disclosure.find_by(pdf: @pdf)
-
-    return unless @disclosure
+    @disclosure = Disclosure.find_by!(pdf: @pdf)
 
     @code = @disclosure.code
     @title = title

--- a/app/controllers/pdfs_controller.rb
+++ b/app/controllers/pdfs_controller.rb
@@ -5,7 +5,17 @@ class PdfsController < ApplicationController
     path = params[:path]
     pdf = path&.split("/")&.last
     @pdf = "#{pdf}.pdf"
-    @code = Disclosure.find_by(pdf: @pdf)&.code
+    @disclosure = Disclosure.find_by(pdf: @pdf)
+
+    return unless @disclosure
+
+    @code = @disclosure.code
+    @title = title
   end
 
+  private
+
+  def title
+    "#{@disclosure.name}の#{@disclosure.title} | iMarket（適時開示ネット）"
+  end
 end

--- a/app/controllers/pdfs_controller.rb
+++ b/app/controllers/pdfs_controller.rb
@@ -2,7 +2,10 @@ class PdfsController < ApplicationController
   layout "pdf"
 
   def show
+    @path = params[:path]
+
     respond_to do |format|
+      format.pdf { render file: "#{Rails.root}/public/404.html" }
       format.any
     end
   end

--- a/app/controllers/pdfs_controller.rb
+++ b/app/controllers/pdfs_controller.rb
@@ -3,6 +3,8 @@ class PdfsController < ApplicationController
 
   def show
     @path = params[:path]
+    pdf = @path&.split("/")&.last
+    @code = Disclosure.find_by(pdf: pdf)&.code
 
     respond_to do |format|
       format.pdf { render file: "#{Rails.root}/public/404.html" }

--- a/app/controllers/pdfs_controller.rb
+++ b/app/controllers/pdfs_controller.rb
@@ -2,9 +2,10 @@ class PdfsController < ApplicationController
   layout "pdf"
 
   def show
-    @path = params[:path]
-    pdf = @path&.split("/")&.last
-    @code = Disclosure.find_by(pdf: pdf)&.code
+    path = params[:path]
+    pdf = path&.split("/")&.last
+    @pdf = "#{pdf}.pdf"
+    @code = Disclosure.find_by(pdf: @pdf)&.code
   end
 
 end

--- a/app/views/layouts/pdf.html.slim
+++ b/app/views/layouts/pdf.html.slim
@@ -3,6 +3,8 @@ html
     meta[charset="utf-8"]
     meta[http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1"]
     meta name="viewport" content="width=device-width, initial-scale=1"
+    title
+      = @title
     scss:
       * {
         box-sizing: border-box;

--- a/app/views/layouts/pdf.html.slim
+++ b/app/views/layouts/pdf.html.slim
@@ -1,0 +1,11 @@
+<html>
+  <body style="margin: 0;">
+    <div>Hello from Google Cloud Run!</div>
+    <iframe id="inlineFrameExample"
+      title="Inline Frame Example"
+      width="100%"
+      height="100%"
+      src="http://localhost/pdf/4368.pdf">
+    </iframe>
+  </body>
+</html>

--- a/app/views/layouts/pdf.html.slim
+++ b/app/views/layouts/pdf.html.slim
@@ -13,6 +13,7 @@ html
         line-height: 1.428571429;
         color: #333333;
         background-color: #fff;
+        margin: 0;
       }
       a {
         text-decoration: none;
@@ -37,7 +38,7 @@ html
         margin-left: 0px;
         margin-right: 0px;
        }
-     .navbar-header:before,
+      .navbar-header:before,
       .navbar-header:after {
         display: table;
         content: " ";
@@ -56,9 +57,35 @@ html
       *:before, *:after {
         box-sizing: border-box;
       }
+      .navbar-right {
+        float: right !important;
+      }
+      @media (min-width: 992px) {
+        .container {
+          width: 970px;
+        }
+      }
+      @media (min-width: 1200px) {
+        .container {
+          width: 1170px;
+        }
+      }
+      @media (max-width: 1300px) {
+        .container{
+          width: 900px;
+        }
+      }
+      @media (min-width: 1300px) {
+        .container{
+          width: 1000px;
+        }
+      }
       @media (max-width: 768px) {
         body {
           font-size: 14px;
+        }
+        .container {
+          width: unset;
         }
         .navbar {
           min-height: 50px;
@@ -70,10 +97,21 @@ html
           font-size: 18px;
           line-height: 20px;
         }
+        .navbar-collapse {
+          display: none;
+        }
+        .navbar-right {
+          color: #595857;
+          padding-top: 10px;
+          padding-bottom: 10px;
+          line-height: 20px;
+          position: relative;
+          display: block;
+          padding: 15px 15px;
+        }
       }
       @media (min-width: 769px) {
         .container {
-          width: 750px;
           padding-left: 0px;
           padding-right: 0px;
           margin-right: auto;
@@ -117,9 +155,6 @@ html
         .navbar-nav.navbar-right:last-child {
           margin-right: 0px;
         }
-        .navbar-right {
-          float: right !important;
-        }
         .navbar-nav {
           margin: 0;
         }
@@ -146,37 +181,22 @@ html
           position: relative;
           display: block;
           padding: 10px 15px;
+          font-size: 16px;
         }
-      }
-      @media (min-width: 992px) {
-        .container {
-          width: 970px;
-        }
-      }
-      @media (min-width: 1200px) {
-        .container {
-          width: 1170px;
-        }
-      }
-      @media (max-width: 1300px) {
-        .container{
-          width: 900px;
-        }
-      }
-      @media (min-width: 1300px) {
-        .container{
-          width: 1000px;
+        a.navbar-right {
+          display: none;
         }
       }
 
-  body style=("margin: 0;")
+  body
     .navbar.navbar-default
       .container
         .navbar-header
           a.navbar-brand href="/"  iMarket（適時開示ネット）
+          a.navbar-right href=("/stocks/#{@code}") 決算短信
         .collapse.navbar-collapse
           ul.nav.navbar-nav.navbar-right
             li
               a href=("/stocks/#{@code}") 決算短信
 
-    iframe#inlineFrameExample height="100%" src=("#{@path}.pdf") title=("Inline Frame Example") width="100%"
+    iframe width="100%" height="100%" src=("#{@path}.pdf")

--- a/app/views/layouts/pdf.html.slim
+++ b/app/views/layouts/pdf.html.slim
@@ -1,11 +1,4 @@
-<html>
-  <body style="margin: 0;">
-    <div>Hello from Google Cloud Run!</div>
-    <iframe id="inlineFrameExample"
-      title="Inline Frame Example"
-      width="100%"
-      height="100%"
-      src="http://localhost/pdf/4368.pdf">
-    </iframe>
-  </body>
-</html>
+html
+  body style=("margin: 0;")
+    div Hello from Google Cloud Run!
+    iframe#inlineFrameExample height="100%" src="http://localhost/pdf/4368.pdf" title=("Inline Frame Example") width="100%"

--- a/app/views/layouts/pdf.html.slim
+++ b/app/views/layouts/pdf.html.slim
@@ -193,10 +193,10 @@ html
       .container
         .navbar-header
           a.navbar-brand href="/"  iMarket（適時開示ネット）
-          a.navbar-right href=("/stocks/#{@code}") 決算短信
+          a.navbar-right href=("/stocks/#{@code}") 決算短信一覧
         .collapse.navbar-collapse
           ul.nav.navbar-nav.navbar-right
             li
-              a href=("/stocks/#{@code}") 決算短信
+              a href=("/stocks/#{@code}") 決算短信一覧
 
     iframe width="100%" height="100%" src=@pdf

--- a/app/views/layouts/pdf.html.slim
+++ b/app/views/layouts/pdf.html.slim
@@ -1,4 +1,91 @@
 html
   body style=("margin: 0;")
-    div Hello from Google Cloud Run!
-    iframe#inlineFrameExample height="100%" src="http://localhost/pdf/4368.pdf" title=("Inline Frame Example") width="100%"
+    .navbar.navbar-default
+      .container
+        .navbar-header
+          a.navbar-brand href="/"  iMarket（適時開示ネット）
+    scss:
+      body {
+          font-size: 12px;
+      }
+      body {
+          font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+          font-size: 14px;
+          line-height: 1.428571429;
+          color: #333333;
+          background-color: #fff;
+      }
+      iframe {
+        border: 0;
+      }
+      @media (min-width: 768px) {
+      .navbar {
+          border-radius: 4px;
+      }
+      .navbar {
+          position: relative;
+          min-height: 50px;
+          border: 1px solid transparent;
+          border-bottom: 0;
+      }
+      }
+      .navbar {
+          min-height: 40px;
+          z-index: 1;
+      }
+      .navbar-default {
+          background-color: #f8f8f8;
+          border-color: #e7e7e7;
+      }
+      @media all{
+      a{background-color:transparent;}
+      a:active,a:hover{outline:0;}
+      @media print{
+      *,*:before,*:after{color:#000!important;text-shadow:none!important;background:transparent!important;box-shadow:none!important;}
+      a,a:visited{text-decoration:underline;}
+      a[href]:after{content:" (" attr(href) ")";}
+      }
+      *{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;}
+      *:before,*:after{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;}
+      a{color:#337ab7;text-decoration:none;}
+      a:hover,a:focus{color:#23527c;text-decoration:underline;}
+      a:focus{outline:5px auto -webkit-focus-ring-color;outline-offset:-2px;}
+      .container{padding-right:15px;padding-left:15px;margin-right:auto;margin-left:auto;}
+      .container:before,.container:after{display:table;content:" ";}
+      .container:after{clear:both;}
+      @media (min-width: 768px){
+      .container{width:750px;}
+      }
+      @media (min-width: 992px){
+      .container{width:970px;}
+      }
+      @media (min-width: 1200px){
+      .container{width:1170px;}
+      }
+      .navbar-header:before,.navbar-header:after{display:table;content:" ";}
+      .navbar-header:after{clear:both;}
+      @media (min-width: 768px){
+      .navbar-header{float:left;}
+      }
+      .container>.navbar-header{margin-right:-15px;margin-left:-15px;}
+      @media (min-width: 768px){
+      .container>.navbar-header{margin-right:0;margin-left:0;}
+      }
+      .navbar-brand{float:left;height:50px;padding:15px 15px;font-size:18px;line-height:20px;}
+      .navbar-brand:hover,.navbar-brand:focus{text-decoration:none;}
+      @media (min-width: 768px){
+      .navbar>.container .navbar-brand{margin-left:-15px;}
+      }
+      .navbar-default .navbar-brand{color:#777;}
+      .navbar-default .navbar-brand:hover,.navbar-default .navbar-brand:focus{color:#5e5e5e;background-color:transparent;}
+      .navbar-default .navbar-brand{color:#595857;}
+      .navbar-brand{padding-top:10px;padding-bottom:10px;font-weight:200;font-size:20px;height:40px;}
+      @media (max-width: 1300px){
+      .container{width:900px;padding-left:0px;padding-right:0px;}
+      }
+      @media (min-width: 1300px){
+      .container{width:1000px;padding-left:0px;padding-right:0px;}
+      }
+      }
+
+    iframe#inlineFrameExample height="100%" src=("#{@path}.pdf") title=("Inline Frame Example") width="100%"

--- a/app/views/layouts/pdf.html.slim
+++ b/app/views/layouts/pdf.html.slim
@@ -3,21 +3,13 @@ html
     meta[charset="utf-8"]
     meta[http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1"]
     meta name="viewport" content="width=device-width, initial-scale=1"
-  body style=("margin: 0;")
-    .navbar.navbar-default
-      .container
-        .navbar-header
-          a.navbar-brand href="/"  iMarket（適時開示ネット）
     scss:
       * {
         box-sizing: border-box;
       }
       body {
-        font-size: 12px;
-      }
-      body {
         font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-        font-size: 14px;
+        font-size: 12px;
         line-height: 1.428571429;
         color: #333333;
         background-color: #fff;
@@ -41,7 +33,33 @@ html
       .navbar-default .navbar-brand {
         color: #595857;
       }
+      .navbar-header {
+        margin-left: 0px;
+        margin-right: 0px;
+       }
+     .navbar-header:before,
+      .navbar-header:after {
+        display: table;
+        content: " ";
+      }
+      *:before, *:after {
+        box-sizing: border-box;
+      }
+      .navbar-header:after {
+        clear: both;
+      }
+      .navbar-header:before,
+      .navbar-header:after {
+        display: table;
+        content: " ";
+      }
+      *:before, *:after {
+        box-sizing: border-box;
+      }
       @media (max-width: 768px) {
+        body {
+          font-size: 14px;
+        }
         .navbar {
           min-height: 50px;
         }
@@ -52,25 +70,6 @@ html
           font-size: 18px;
           line-height: 20px;
         }
-        .navbar-header:before,
-        .navbar-header:after {
-          display: table;
-          content: " ";
-        }
-        *:before, *:after {
-          box-sizing: border-box;
-        }
-        .navbar-header:after {
-          clear: both;
-        }
-        .navbar-header:before,
-        .navbar-header:after {
-          display: table;
-          content: " ";
-        }
-        *:before, *:after {
-          box-sizing: border-box;
-        }
       }
       @media (min-width: 769px) {
         .container {
@@ -79,6 +78,10 @@ html
           padding-right: 0px;
           margin-right: auto;
           margin-left: auto;
+          height: 40px; // 追加
+        }
+        .navbar-header {
+          float: left;
         }
         .navbar-brand {
           font-weight: 200;
@@ -88,6 +91,61 @@ html
           padding: 10px 15px;
           line-height: 20px;
           margin-left: -15px;
+        }
+        .navbar-collapse {
+          width: auto;
+          border-top: 0;
+          box-shadow: none;
+          padding-right: 15px;
+          padding-left: 15px;
+        }
+        .navbar-collapse.collapse {
+          display: block !important;
+          height: auto !important;
+          padding-bottom: 0;
+          overflow: visible !important;
+        }
+        .container > .navbar-collapse {
+          margin-right: 0;
+          margin-left: 0;
+        }
+        .navbar-collapse:before,
+        .navbar-collapse:after {
+          display: table;
+          content: " ";
+        }
+        .navbar-nav.navbar-right:last-child {
+          margin-right: 0px;
+        }
+        .navbar-right {
+          float: right !important;
+        }
+        .navbar-nav {
+          margin: 0;
+        }
+        .nav {
+          padding-left: 0;
+          list-style: none;
+        }
+        .nav:before, .nav:after {
+          display: table;
+          content: " ";
+        }
+        .navbar-nav > li {
+          float: left;
+        }
+        .nav > li {
+          position: relative;
+          display: block;
+        }
+        .navbar-nav > li > a {
+          color: #595857;
+          padding-top: 10px;
+          padding-bottom: 10px;
+          line-height: 20px;
+          position: relative;
+          display: block;
+          padding: 10px 15px;
         }
       }
       @media (min-width: 992px) {
@@ -110,5 +168,15 @@ html
           width: 1000px;
         }
       }
+
+  body style=("margin: 0;")
+    .navbar.navbar-default
+      .container
+        .navbar-header
+          a.navbar-brand href="/"  iMarket（適時開示ネット）
+        .collapse.navbar-collapse
+          ul.nav.navbar-nav.navbar-right
+            li
+              a href=("/stocks/#{@code}") 決算短信
 
     iframe#inlineFrameExample height="100%" src=("#{@path}.pdf") title=("Inline Frame Example") width="100%"

--- a/app/views/layouts/pdf.html.slim
+++ b/app/views/layouts/pdf.html.slim
@@ -1,91 +1,114 @@
 html
+  head
+    meta[charset="utf-8"]
+    meta[http-equiv="X-UA-Compatible" content="IE=Edge,chrome=1"]
+    meta name="viewport" content="width=device-width, initial-scale=1"
   body style=("margin: 0;")
     .navbar.navbar-default
       .container
         .navbar-header
           a.navbar-brand href="/"  iMarket（適時開示ネット）
     scss:
-      body {
-          font-size: 12px;
+      * {
+        box-sizing: border-box;
       }
       body {
-          font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-          font-size: 14px;
-          line-height: 1.428571429;
-          color: #333333;
-          background-color: #fff;
+        font-size: 12px;
+      }
+      body {
+        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+        font-size: 14px;
+        line-height: 1.428571429;
+        color: #333333;
+        background-color: #fff;
+      }
+      a {
+        text-decoration: none;
       }
       iframe {
         border: 0;
       }
-      @media (min-width: 768px) {
       .navbar {
-          border-radius: 4px;
-      }
-      .navbar {
-          position: relative;
-          min-height: 50px;
-          border: 1px solid transparent;
-          border-bottom: 0;
-      }
-      }
-      .navbar {
-          min-height: 40px;
-          z-index: 1;
+        position: relative;
+        min-height: 40px;
+        z-index: 1;
+        border: 1px solid #e7e7e7;
       }
       .navbar-default {
-          background-color: #f8f8f8;
-          border-color: #e7e7e7;
+        background-color: #f8f8f8;
+        border-color: #e7e7e7;
       }
-      @media all{
-      a{background-color:transparent;}
-      a:active,a:hover{outline:0;}
-      @media print{
-      *,*:before,*:after{color:#000!important;text-shadow:none!important;background:transparent!important;box-shadow:none!important;}
-      a,a:visited{text-decoration:underline;}
-      a[href]:after{content:" (" attr(href) ")";}
+      .navbar-default .navbar-brand {
+        color: #595857;
       }
-      *{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;}
-      *:before,*:after{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;}
-      a{color:#337ab7;text-decoration:none;}
-      a:hover,a:focus{color:#23527c;text-decoration:underline;}
-      a:focus{outline:5px auto -webkit-focus-ring-color;outline-offset:-2px;}
-      .container{padding-right:15px;padding-left:15px;margin-right:auto;margin-left:auto;}
-      .container:before,.container:after{display:table;content:" ";}
-      .container:after{clear:both;}
-      @media (min-width: 768px){
-      .container{width:750px;}
+      @media (max-width: 768px) {
+        .navbar {
+          min-height: 50px;
+        }
+        .navbar-brand {
+          float: left;
+          height: 50px;
+          padding: 15px 15px;
+          font-size: 18px;
+          line-height: 20px;
+        }
+        .navbar-header:before,
+        .navbar-header:after {
+          display: table;
+          content: " ";
+        }
+        *:before, *:after {
+          box-sizing: border-box;
+        }
+        .navbar-header:after {
+          clear: both;
+        }
+        .navbar-header:before,
+        .navbar-header:after {
+          display: table;
+          content: " ";
+        }
+        *:before, *:after {
+          box-sizing: border-box;
+        }
       }
-      @media (min-width: 992px){
-      .container{width:970px;}
+      @media (min-width: 769px) {
+        .container {
+          width: 750px;
+          padding-left: 0px;
+          padding-right: 0px;
+          margin-right: auto;
+          margin-left: auto;
+        }
+        .navbar-brand {
+          font-weight: 200;
+          font-size: 20px;
+          height: 40px;
+          float: left;
+          padding: 10px 15px;
+          line-height: 20px;
+          margin-left: -15px;
+        }
       }
-      @media (min-width: 1200px){
-      .container{width:1170px;}
+      @media (min-width: 992px) {
+        .container {
+          width: 970px;
+        }
       }
-      .navbar-header:before,.navbar-header:after{display:table;content:" ";}
-      .navbar-header:after{clear:both;}
-      @media (min-width: 768px){
-      .navbar-header{float:left;}
+      @media (min-width: 1200px) {
+        .container {
+          width: 1170px;
+        }
       }
-      .container>.navbar-header{margin-right:-15px;margin-left:-15px;}
-      @media (min-width: 768px){
-      .container>.navbar-header{margin-right:0;margin-left:0;}
+      @media (max-width: 1300px) {
+        .container{
+          width: 900px;
+        }
       }
-      .navbar-brand{float:left;height:50px;padding:15px 15px;font-size:18px;line-height:20px;}
-      .navbar-brand:hover,.navbar-brand:focus{text-decoration:none;}
-      @media (min-width: 768px){
-      .navbar>.container .navbar-brand{margin-left:-15px;}
-      }
-      .navbar-default .navbar-brand{color:#777;}
-      .navbar-default .navbar-brand:hover,.navbar-default .navbar-brand:focus{color:#5e5e5e;background-color:transparent;}
-      .navbar-default .navbar-brand{color:#595857;}
-      .navbar-brand{padding-top:10px;padding-bottom:10px;font-weight:200;font-size:20px;height:40px;}
-      @media (max-width: 1300px){
-      .container{width:900px;padding-left:0px;padding-right:0px;}
-      }
-      @media (min-width: 1300px){
-      .container{width:1000px;padding-left:0px;padding-right:0px;}
-      }
+      @media (min-width: 1300px) {
+        .container{
+          width: 1000px;
+        }
       }
 
     iframe#inlineFrameExample height="100%" src=("#{@path}.pdf") title=("Inline Frame Example") width="100%"

--- a/app/views/layouts/pdf.html.slim
+++ b/app/views/layouts/pdf.html.slim
@@ -199,4 +199,4 @@ html
             li
               a href=("/stocks/#{@code}") 決算短信
 
-    iframe width="100%" height="100%" src=("#{@path}.pdf")
+    iframe width="100%" height="100%" src=@pdf

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,29 +1,32 @@
 Rails.application.routes.draw do
-  root 'disclosures#index'
+  root "disclosures#index"
 
   # 開示情報
-  get 'disclosures/:date', to: 'disclosures#index', as: 'disclosures'
+  get "disclosures/:date", to: "disclosures#index", as: "disclosures"
 
   # 銘柄
-  resources 'stocks', only: [:show] do
-    get 'search', on: :collection
+  resources "stocks", only: [:show] do
+    get "search", on: :collection
   end
 
   # 株価
-  resources 'stock_prices', only: [] do
+  resources "stock_prices", only: [] do
     member do
-      get 'per'
-      get 'pbr'
+      get "per"
+      get "pbr"
     end
   end
+
+  # PDF（iMrket以外）
+  get "pdf/*path", to: "pdfs#show"
 
   # API
   namespace :api, defaults: { format: :json } do
     resources :stock_prices, param: :code, only: [:show]
     resource :announce, only: [] do
       member do
-        get 'financial_results'
-        get 'forecast'
+        get "financial_results"
+        get "forecast"
       end
     end
   end

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,3 +4,8 @@ Disallow: /disclosures/2016*
 Disallow: /disclosures/2015*
 Disallow: /disclosures/2014*
 Disallow: /disclosures/2013*
+Disallow: /pdf/2017*
+Disallow: /pdf/2016*
+Disallow: /pdf/2015*
+Disallow: /pdf/2014*
+Disallow: /pdf/2013*


### PR DESCRIPTION
- [x] Nginxの設定確認
- [x] 表示部分の実装
- [x] スタイル調整
- [x] SEO対策
  - titleのみ

備考

- URL直打ちでPDFが読み込まれるが、リロードするとリダイレクトする
  - iMarket 経由で先に読み込んだ場合のみ
- スマホ画面で画面が真っ白
  - スマホの場合は常にPDFを表示
- クローラ対策どうする？
  - canonicalは指定せず、しばらく様子見