### PR TITLE
開示一覧に年初来を表示する

### DIFF
--- a/app/assets/stylesheets/partials/_disclosures.scss
+++ b/app/assets/stylesheets/partials/_disclosures.scss
@@ -56,6 +56,13 @@
         margin-right: auto;
       }
     }
+
+    .ytd_shorter {
+      padding-left: 6px;
+      padding-right: 0px;
+      font-size: 11px;
+      vertical-align: middle;
+    }
   }
 
   .table-disclosure-all {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -186,6 +186,15 @@ module ApplicationHelper
     num < 0 ? span_red(num_percent) : num_percent
   end
 
+  def red_hundred_p_shorter(num)
+    return unless num
+
+    num = (num * 100)
+    num = num > 100 ? num.floor : num.round(1)
+    num_percent = "#{num}%"
+    num < 0 ? span_red(num_percent) : num_percent
+  end
+
   def red_delimiter(num)
     return unless num
 
@@ -201,6 +210,6 @@ module ApplicationHelper
   end
 
   def span_red(value)
-    content_tag(:span, value, style: "color:#d3381c")
+    content_tag(:span, value, "class": "red")
   end
 end

--- a/app/views/disclosures/index.html.slim
+++ b/app/views/disclosures/index.html.slim
@@ -91,12 +91,8 @@
                 td.text-right = red_delimiter_per_share(summary.prior_net_income_per_share)
                 td.text-center = link_to_stock(disclosure)
               tr
-                - if tynmarket?
-                  td.fcf-ratio
-                    div
-                      = disclosure.stock&.fcf_ratio
-                - else
-                  td
+                td.ytd_shorter
+                  = red_hundred_p_shorter(disclosure.stock.ytd)
                 td
                   span.float-right = per_in_disclosure(disclosure)
                 td
@@ -159,7 +155,8 @@
                   td.text-right = red_delimiter_per_share(forecast.previous_forecast_net_income_per_share)
                   td.text-center = link_to_stock disclosure
                 tr
-                  td
+                  td.ytd_shorter
+                    = red_hundred_p_shorter(disclosure.stock.ytd)
                   td
                     span.float-right = per_in_disclosure(disclosure)
                   td


### PR DESCRIPTION
見辛い？

![2020年04月17日の決算短信   iMarket（適時開示ネット）](https://user-images.githubusercontent.com/1695713/79682859-c01fc400-8260-11ea-91fe-2da08a0f61ac.png)
