### PR TITLE
2014年の短信を非表示にする

### DIFF
--- a/app/helpers/stocks_helper.rb
+++ b/app/helpers/stocks_helper.rb
@@ -26,7 +26,7 @@ module StocksHelper
   end
 
   def show_summary?(release_date)
-    release_date.year >= 2014
+    release_date.year >= 2015
   end
 
   def thead_summary


### PR DESCRIPTION
ディスクの利用率が90%を超えたので、2014年の短信を非表示にして削除する。