### PR TITLE
開示一覧のCSSを調整

### DIFF
--- a/app/assets/stylesheets/partials/_disclosures.scss
+++ b/app/assets/stylesheets/partials/_disclosures.scss
@@ -13,6 +13,10 @@
     font-size: $font-size-small;
     margin-bottom: 5px;
 
+    &.table-disclosure:not(:nth-child(1)) {
+      border-top: 0;
+    }
+
     & > thead {
       & > tr > th {
         &.w_release   { width: 5%;    }

--- a/config/database.yml
+++ b/config/database.yml
@@ -37,8 +37,9 @@ development:
   #<<: *default_dev
   #database: imarket_development
   <<: *default
-  host: <%= ENV["DB_IP"] %>
+  host: 127.0.0.1
   database: <%= ENV["MYSQL_DATABASE"] %>
+  port: 13306
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".


### PR DESCRIPTION
Chromeを更新したらborder-topが二重に表示されるようになった。